### PR TITLE
Make link text correspond to resource type name

### DIFF
--- a/website/azuredevops.erb
+++ b/website/azuredevops.erb
@@ -65,7 +65,7 @@
                   <a href="/docs/providers/azuredevops/r/agent_queue.html">azuredevops_agent_queue</a>
                 </li>
                 <li>
-                  <a href="/docs/providers/azuredevops/r/azure_git_repository.html">azuredevops_azure_git_repository</a>
+                  <a href="/docs/providers/azuredevops/r/azure_git_repository.html">azuredevops_git_repository</a>
                 </li>
                 <li>
                   <a href="/docs/providers/azuredevops/r/branch_policy_build_validation.html">azuredevops_branch_policy_build_validation</a>


### PR DESCRIPTION
Sorry for the nit but was slightly confused by not being able to find `azuredevops_git_repository` in the sidebar.  After clicking on `azuredevops_azure_git_repository` I found what I was looking for but this change should reduce friction for others.  I might suggest changing the linked pages names too but that's stylistic.

## All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] I have updated the documentation accordingly.
* [n/a] I have added tests to cover my changes.
* [n/a] All new and existing tests passed.
* [n/a] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [x] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

n/a

Issue Number: none

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [x] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

n/a

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->